### PR TITLE
:fire: remove ios define 💢

### DIFF
--- a/FConvenience.h
+++ b/FConvenience.h
@@ -258,14 +258,6 @@ static inline NSValue  * OVERLOADABLE FBox(NSRange x) { return [NSValue valueWit
 #   define UIIdiomString() ((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? @"ipad" : @"iphone")
 #   define DeviceIsIPad() (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
 
-#    define iOS Version Detection
-#    ifndef __IPHONE_7_0
-#        define __IPHONE_7_0 (70000)
-#    endif
-#    ifndef NSFoundationVersionNumber_iOS_6_1
-#        define NSFoundationVersionNumber_iOS_6_1 (DBL_MAX)
-#    endif
-
 #   define SixOrOlder() (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1)
 #endif
 


### PR DESCRIPTION
このこはKronaでSubmoduleとして取り込んでいます。

Kronaで

`if (@available(iOS 14.0, *))` とか使おうとするとこの `#define iOS` と avaiableの中の `iOS`がバッティングして
エラーを起こしていたので、使用箇所が無いので削除しました。

なんだろうなぁ。。。
